### PR TITLE
parasails-has-no-page-script check

### DIFF
--- a/dist/parasails.js
+++ b/dist/parasails.js
@@ -723,8 +723,11 @@
     if (!pageName) { throw new Error('1st argument (page name) is required'); }
     if (!def) { throw new Error('2nd argument (page script definition) is required'); }
 
+    // Don't look for a matching page-script for elements that share an id with a page (checking for a `parasails-has-no-page-script` attribute)
+    var domsToIgnore = $('#'+pageName).parents().filter('[parasails-has-no-page-script]');
+
     // Only actually build+load this page script if it is relevant for the current contents of the DOM.
-    if (!document.getElementById(pageName)) { return; }//eslint-disable-line no-undef
+    if (!document.getElementById(pageName) || domsToIgnore.length >= 1) { return; }//eslint-disable-line no-undef
 
     // Spinlock
     if (didAlreadyLoadPageScript) { throw new Error('Cannot load page script (`'+pageName+') because a page script has already been loaded on this page.'); }

--- a/dist/parasails.js
+++ b/dist/parasails.js
@@ -724,10 +724,10 @@
     if (!def) { throw new Error('2nd argument (page script definition) is required'); }
 
     // Don't look for a matching DOM element (by "id") within anything that has `parasails-has-no-page-script`
-    var domsToIgnore = $('#'+pageName).parents().filter('[parasails-has-no-page-script]');
+    var elementsToIgnoreWithin = $('#'+pageName).parents().filter('[parasails-has-no-page-script]');
 
     // Only actually build+load this page script if it is relevant for the current contents of the DOM.
-    if (!document.getElementById(pageName) || domsToIgnore.length >= 1) { return; }//eslint-disable-line no-undef
+    if (!window.document.getElementById(pageName) || elementsToIgnoreWithin.length >= 1) { return; }
 
     // Spinlock
     if (didAlreadyLoadPageScript) { throw new Error('Cannot load page script (`'+pageName+') because a page script has already been loaded on this page.'); }

--- a/dist/parasails.js
+++ b/dist/parasails.js
@@ -167,7 +167,7 @@
     // > This is particularly useful for catching loose top-level properties
     // > that were intended to be within `data` or `methods`, etc.)
     if (currentModuleEntityNoun === 'page script' || currentModuleEntityNoun === 'component') {
-      // FUTURE: don't allow page-script only things on components
+      // FUTURE: don't allow page script only things on components
 
       var LEGAL_TOP_LVL_KEYS = [
         // Everyday page script stuff:
@@ -723,7 +723,7 @@
     if (!pageName) { throw new Error('1st argument (page name) is required'); }
     if (!def) { throw new Error('2nd argument (page script definition) is required'); }
 
-    // Don't look for a matching page-script for elements that share an id with a page (checking for a `parasails-has-no-page-script` attribute)
+    // Don't look for a matching DOM element (by "id") within anything that has `parasails-has-no-page-script`
     var domsToIgnore = $('#'+pageName).parents().filter('[parasails-has-no-page-script]');
 
     // Only actually build+load this page script if it is relevant for the current contents of the DOM.

--- a/dist/parasails.js
+++ b/dist/parasails.js
@@ -724,10 +724,21 @@
     if (!def) { throw new Error('2nd argument (page script definition) is required'); }
 
     // Don't look for a matching DOM element (by "id") within anything that has `parasails-has-no-page-script`
-    var elementsToIgnoreWithin = $('#'+pageName).parents().filter('[parasails-has-no-page-script]');
+    // FUTURE: Move this check a bit further below, probably without defining the variable, and just add another avast (aka early return)
+    var isWithinIgnoredElements;
+    if ($) {
+      // Note that, luckily, this works even without waiting for the DOM to be ready according to jQuery.  (i.e. $(()=>{ … }))
+      isWithinIgnoredElements = (
+        $('#'+pageName).parents().filter('[parasails-has-no-page-script]')
+      ).length >= 1;
+    } else {
+      // For simplicity, this check is skipped if jQuery is not available.
+      // FUTURE: Implement with vanilla JS here
+      isWithinIgnoredElements = false;
+    }
 
     // Only actually build+load this page script if it is relevant for the current contents of the DOM.
-    if (!window.document.getElementById(pageName) || elementsToIgnoreWithin.length >= 1) { return; }
+    if (!window.document.getElementById(pageName) || isWithinIgnoredElements) { return; }
 
     // Spinlock
     if (didAlreadyLoadPageScript) { throw new Error('Cannot load page script (`'+pageName+') because a page script has already been loaded on this page.'); }


### PR DESCRIPTION
Adding a check in registerPage() to check for a `parasails-has-no-page-script` attribute. If you have an html element with an `id` that matches the name of a page you can add a `parasails-has-no-page-script` attribute to the element and parasails will no longer try to attach a page script to it.
